### PR TITLE
fix: remove duplicate light/dark mode toggle from mobile header

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -49,24 +49,15 @@ export function Navigation({ children }: NavigationProps) {
       padding="md"
     >
       <AppShell.Header hiddenFrom="md">
-        <Group h="100%" px="md" justify="space-between">
-          <Group>
-            <Burger opened={opened} onClick={toggle} size="sm" />
-            <Text size="lg" fw={700}>MatchExec</Text>
-          </Group>
-          <ActionIcon
-            variant="outline"
-            size={30}
-            onClick={() => toggleColorScheme()}
-          >
-            {colorScheme === 'dark' ? <IconSun size="16" /> : <IconMoon size="16" />}
-          </ActionIcon>
+        <Group h="100%" px="md">
+          <Burger opened={opened} onClick={toggle} size="sm" />
+          <Text size="lg" fw={700}>MatchExec</Text>
         </Group>
       </AppShell.Header>
 
       <AppShell.Navbar p="md">
         <AppShell.Section>
-          <Group justify="space-between" mb="md" visibleFrom="md">
+          <Group justify="space-between" mb="md">
             <Text size="xl" fw={700}>MatchExec</Text>
             <ActionIcon
               variant="outline"


### PR DESCRIPTION
Fixes #83

Removed the duplicate light/dark mode toggle from the mobile header bar, keeping only the one in the hamburger menu.

## Changes
- Removed ActionIcon toggle from mobile header bar (AppShell.Header)
- Removed `visibleFrom='md'` constraint from navbar toggle
- Now only one toggle appears: in the navbar/hamburger menu on both mobile and desktop

## Result
- **Mobile**: No toggle in header bar, toggle only appears when hamburger menu is opened
- **Desktop**: Toggle remains in the sidebar as before

Generated with [Claude Code](https://claude.ai/code)