### PR TITLE
Fix runtime error by moving version files to correct location

### DIFF
--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getVersionInfo } from '../../../../lib/version-server';
+import { getVersionInfo } from '@/lib/version-server';
 import { logger } from '@/lib/logger';
 
 export async function GET() {

--- a/src/lib/version-client.ts
+++ b/src/lib/version-client.ts
@@ -1,0 +1,24 @@
+export interface VersionInfo {
+  version: string;
+  branch: string;
+  commitHash: string;
+  isDev: boolean;
+}
+
+export async function getVersionInfo(): Promise<VersionInfo> {
+  try {
+    const response = await fetch('/api/version');
+    if (!response.ok) {
+      throw new Error('Failed to fetch version info');
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching version info:', error);
+    return {
+      version: 'unknown',
+      branch: 'unknown',
+      commitHash: 'unknown',
+      isDev: false
+    };
+  }
+}

--- a/src/lib/version-server.ts
+++ b/src/lib/version-server.ts
@@ -1,0 +1,13 @@
+import pkg from '../package.json';
+
+export function getVersionInfo() {
+  const baseVersion = pkg.version;
+  
+  // Always use fallback in production/Docker to avoid git errors
+  return {
+    version: `v${baseVersion}`,
+    branch: 'production',
+    commitHash: 'docker',
+    isDev: false
+  };
+}


### PR DESCRIPTION
Moved version-client.ts and version-server.ts from /lib/ to /src/lib/ to match the import paths used in components. The Navigation component was importing from @/lib/version-client which resolves to src/lib/, causing a runtime error when the module couldn't be found.

Also updated the version API route to use the proper import path.

Fixes: Objects are not valid as a React child runtime error