### PR TITLE
Fix build error: Replace package.json import with fs.readFileSync

### DIFF
--- a/src/lib/version-server.ts
+++ b/src/lib/version-server.ts
@@ -1,8 +1,12 @@
-import pkg from '../package.json';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 export function getVersionInfo() {
-  const baseVersion = pkg.version;
-  
+  // Read package.json at runtime to avoid Next.js import issues
+  const packageJsonPath = join(process.cwd(), 'package.json');
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  const baseVersion = packageJson.version;
+
   // Always use fallback in production/Docker to avoid git errors
   return {
     version: `v${baseVersion}`,


### PR DESCRIPTION
- Fixed "Module not found: Can't resolve '../package.json'" build error
- Changed src/lib/version-server.ts to use fs.readFileSync instead of import
- This resolves Next.js compatibility issues with JSON imports
- Tested with successful production build