### PR TITLE
Replace Progress bars with Stepper components in creation flows

### DIFF
--- a/src/components/create-match-page.tsx
+++ b/src/components/create-match-page.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Container, Stack, Group, ActionIcon, Title, Breadcrumbs, Anchor, Progress, Box, Text } from '@mantine/core';
-import { IconArrowLeft } from '@tabler/icons-react';
+import { Container, Stack, Group, ActionIcon, Title, Breadcrumbs, Anchor, Stepper } from '@mantine/core';
+import { IconArrowLeft, IconDeviceGamepad2, IconCalendar, IconBell, IconMap } from '@tabler/icons-react';
 import { showError, showSuccess } from '@/lib/notifications';
 import { logger } from '@/lib/logger/client';
 import { MapNoteModal } from './map-note-modal';
@@ -323,8 +323,6 @@ export function CreateMatchPage() {
     }
   };
 
-  const progressValue = (currentStep / 4) * 100;
-
   return (
     <Container size="md" py={{ base: "md", sm: "xl" }} px={{ base: "md", sm: "xl" }}>
       <Stack gap="md">
@@ -352,14 +350,13 @@ export function CreateMatchPage() {
           ))}
         </Breadcrumbs>
 
-        {/* Progress Indicator */}
-        <Box>
-          <Group justify="space-between" mb="xs">
-            <Text size="sm" fw={500}>{getStepTitle()}</Text>
-            <Text size="xs" c="dimmed">Step {currentStep} of 4</Text>
-          </Group>
-          <Progress value={progressValue} size="xs" />
-        </Box>
+        {/* Step Indicator */}
+        <Stepper active={currentStep - 1} size="sm">
+          <Stepper.Step icon={<IconDeviceGamepad2 size={18} />} />
+          <Stepper.Step icon={<IconCalendar size={18} />} />
+          <Stepper.Step icon={<IconBell size={18} />} />
+          <Stepper.Step icon={<IconMap size={18} />} />
+        </Stepper>
 
         {/* Step Content */}
         {currentStep === 1 && (

--- a/src/components/create-tournament-page.tsx
+++ b/src/components/create-tournament-page.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Container, Stack, Group, Title, Breadcrumbs, Anchor, Progress, Button } from '@mantine/core';
-import { IconArrowLeft } from '@tabler/icons-react';
+import { Container, Stack, Group, Title, Breadcrumbs, Anchor, Button, Stepper } from '@mantine/core';
+import { IconArrowLeft, IconDeviceGamepad2, IconCalendar, IconTrophy, IconUsers, IconListCheck } from '@tabler/icons-react';
 import { showError, showWarning, showSuccess } from '@/lib/notifications';
 import { logger } from '@/lib/logger/client';
 
@@ -194,10 +194,6 @@ export function CreateTournamentPage() {
     }
   };
 
-  const getProgressValue = () => {
-    return (currentStep / 5) * 100;
-  };
-
   return (
     <Container size="lg" py="md">
       <Stack gap="md">
@@ -215,8 +211,14 @@ export function CreateTournamentPage() {
           </Button>
         </Group>
 
-        {/* Progress */}
-        <Progress value={getProgressValue()} size="sm" />
+        {/* Step Indicator */}
+        <Stepper active={currentStep - 1} size="sm">
+          <Stepper.Step icon={<IconDeviceGamepad2 size={18} />} />
+          <Stepper.Step icon={<IconCalendar size={18} />} />
+          <Stepper.Step icon={<IconTrophy size={18} />} />
+          <Stepper.Step icon={<IconUsers size={18} />} />
+          <Stepper.Step icon={<IconListCheck size={18} />} />
+        </Stepper>
 
         {/* Step Content */}
         {currentStep === 1 && (


### PR DESCRIPTION
## Summary
Replaced linear progress indicators with Mantine's `Stepper` component in both the match and tournament creation pages for improved visual step navigation and user experience.

## Key Changes
- **create-match-page.tsx**:
  - Replaced `Progress` component with `Stepper` component showing 4 steps
  - Added icon imports for step visualization (`IconDeviceGamepad2`, `IconCalendar`, `IconBell`, `IconMap`)
  - Removed `progressValue` calculation and progress bar markup
  - Updated step indicator to use `Stepper.Step` with custom icons for each step

- **create-tournament-page.tsx**:
  - Replaced `Progress` component with `Stepper` component showing 5 steps
  - Added icon imports for step visualization (`IconDeviceGamepad2`, `IconCalendar`, `IconTrophy`, `IconUsers`, `IconListCheck`)
  - Removed `getProgressValue()` helper function
  - Updated step indicator to use `Stepper.Step` with custom icons for each step

## Implementation Details
- Both components now use `Stepper` with `active={currentStep - 1}` to track the current step (accounting for 0-based indexing)
- Each step is represented by a semantic icon that reflects the step's purpose (e.g., gamepad for match/tournament setup, calendar for scheduling, etc.)
- Stepper size set to "sm" for consistent, compact presentation
- Removed unnecessary UI elements (step title text and step counter in match creation)

https://claude.ai/code/session_01YTxpyM4Esw3b52iLPUxieY