### PR TITLE
Add Helm version sync check to PR validation workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -172,6 +172,31 @@ jobs:
         if: steps.health.outcome == 'failure' || steps.build.outcome == 'failure'
         run: exit 1
 
+  helm-version-sync:
+    name: Helm Version Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check appVersion matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          CHART_APP_VERSION=$(grep '^appVersion:' kubernetes/helm/matchexec/Chart.yaml | sed 's/appVersion: *"\?\([^"]*\)"\?/\1/')
+          echo "package.json version:   $PKG_VERSION"
+          echo "Chart.yaml appVersion:  $CHART_APP_VERSION"
+          echo "## Helm Version Sync" >> $GITHUB_STEP_SUMMARY
+          echo "| File | Version |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|---------|" >> $GITHUB_STEP_SUMMARY
+          echo "| package.json | \`$PKG_VERSION\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Chart.yaml appVersion | \`$CHART_APP_VERSION\` |" >> $GITHUB_STEP_SUMMARY
+          if [ "$PKG_VERSION" != "$CHART_APP_VERSION" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "❌ Version mismatch — update \`appVersion\` in \`kubernetes/helm/matchexec/Chart.yaml\` to match \`package.json\`" >> $GITHUB_STEP_SUMMARY
+            echo "Error: appVersion \"$CHART_APP_VERSION\" in Chart.yaml does not match version \"$PKG_VERSION\" in package.json"
+            exit 1
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Versions match" >> $GITHUB_STEP_SUMMARY
+
   build:
     name: Build
     runs-on: ${{ contains(fromJSON('["slamanna212", "dependabot[bot]"]'), github.actor) && 'rapture-matchexec' || 'ubuntu-latest' }}


### PR DESCRIPTION
## Summary
Added a new CI job to the PR checks workflow that validates the Helm chart's `appVersion` matches the application version in `package.json`.

## Key Changes
- Added `helm-version-sync` job to `.github/workflows/pr-checks.yml`
- Extracts version from `package.json` and compares it with `appVersion` in `kubernetes/helm/matchexec/Chart.yaml`
- Fails the check if versions don't match with a clear error message
- Generates a summary table in the GitHub Actions step summary showing both versions and validation status

## Implementation Details
- Uses `grep` and `sed` to parse the `appVersion` field from the Helm Chart.yaml file
- Handles quoted and unquoted version values in the YAML
- Provides user-friendly output in both the step summary and console logs
- Displays a ✅ or ❌ indicator in the step summary for quick visual feedback
- Prevents version drift between the application and its Helm chart deployment

https://claude.ai/code/session_013ENge3t7gqCWY2K8vSsmNC