### PR TITLE
Add Helm chart publishing and version sync automation

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -180,25 +180,44 @@ jobs:
     needs: [lint-and-typecheck]
     steps:
       - uses: actions/checkout@v4
-      - name: Check appVersion matches package.json version
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+      - name: Check Chart.yaml versions match package.json
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
+          CHART_VERSION=$(grep '^version:' kubernetes/helm/matchexec/Chart.yaml | sed 's/version: *//')
           CHART_APP_VERSION=$(grep '^appVersion:' kubernetes/helm/matchexec/Chart.yaml | sed 's/appVersion: *"\?\([^"]*\)"\?/\1/')
           echo "package.json version:   $PKG_VERSION"
+          echo "Chart.yaml version:     $CHART_VERSION"
           echo "Chart.yaml appVersion:  $CHART_APP_VERSION"
           echo "## Helm Version Sync" >> $GITHUB_STEP_SUMMARY
-          echo "| File | Version |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|---------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| package.json | \`$PKG_VERSION\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Chart.yaml version | \`$CHART_VERSION\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Chart.yaml appVersion | \`$CHART_APP_VERSION\` |" >> $GITHUB_STEP_SUMMARY
+          FAILED=0
+          if [ "$PKG_VERSION" != "$CHART_VERSION" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "❌ version mismatch — update \`version\` in \`kubernetes/helm/matchexec/Chart.yaml\` to match \`package.json\`" >> $GITHUB_STEP_SUMMARY
+            echo "Error: version \"$CHART_VERSION\" in Chart.yaml does not match version \"$PKG_VERSION\" in package.json"
+            FAILED=1
+          fi
           if [ "$PKG_VERSION" != "$CHART_APP_VERSION" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "❌ Version mismatch — update \`appVersion\` in \`kubernetes/helm/matchexec/Chart.yaml\` to match \`package.json\`" >> $GITHUB_STEP_SUMMARY
+            echo "❌ appVersion mismatch — update \`appVersion\` in \`kubernetes/helm/matchexec/Chart.yaml\` to match \`package.json\`" >> $GITHUB_STEP_SUMMARY
             echo "Error: appVersion \"$CHART_APP_VERSION\" in Chart.yaml does not match version \"$PKG_VERSION\" in package.json"
-            exit 1
+            FAILED=1
           fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Versions match" >> $GITHUB_STEP_SUMMARY
+          if [ "$FAILED" = "0" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "✅ All versions match" >> $GITHUB_STEP_SUMMARY
+          fi
+          exit $FAILED
+      - name: Helm lint
+        run: helm lint kubernetes/helm/matchexec
 
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,10 +129,40 @@ jobs:
         gh release create "v${{ needs.check-version.outputs.version }}" \
           --title "Release v${{ needs.check-version.outputs.version }}" \
           --notes "## ✨ New Features
-          
+
         ## 🐛 Bug Fixes
 
         ## 🎮 Game Data
-        
-        **Docker Image:** \`ghcr.io/${{ github.actor }}/matchexec:v${{ needs.check-version.outputs.version }}\`" \
+
+        **Docker Image:** \`ghcr.io/${{ github.actor }}/matchexec:v${{ needs.check-version.outputs.version }}\`
+
+        **Helm Chart:**
+        \`\`\`
+        helm install matchexec oci://ghcr.io/${{ github.actor }}/charts/matchexec --version ${{ needs.check-version.outputs.version }}
+        \`\`\`" \
           --draft
+
+  helm-publish:
+    runs-on: ubuntu-latest
+    needs: [check-version, release]
+    if: needs.check-version.outputs.tag_exists == 'false'
+    permissions:
+      packages: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: latest
+
+    - name: Log in to GHCR
+      run: echo "${{ secrets.GHCR_TOKEN }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+
+    - name: Package Helm chart
+      run: helm package kubernetes/helm/matchexec
+
+    - name: Push Helm chart to GHCR OCI
+      run: helm push matchexec-${{ needs.check-version.outputs.version }}.tgz oci://ghcr.io/${{ github.actor }}/charts

--- a/kubernetes/helm/matchexec/Chart.yaml
+++ b/kubernetes/helm/matchexec/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: matchexec
 description: MatchExec Discord Match & Tournament Bot
 type: application
-version: 0.1.0
+version: 0.8.0
 appVersion: "0.8.0"
 keywords:
   - discord

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:all": "npm run test",
     "prod:start": "npx pm2 start ecosystem.config.js",
     "prod:stop": "npx pm2 stop ecosystem.config.js",
+    "version": "node scripts/update-helm-version.mjs",
     "version:patch": "npm version patch --no-git-tag-version",
     "version:minor": "npm version minor --no-git-tag-version",
     "version:major": "npm version major --no-git-tag-version",

--- a/scripts/update-helm-version.mjs
+++ b/scripts/update-helm-version.mjs
@@ -1,0 +1,9 @@
+import { readFileSync, writeFileSync } from 'fs';
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf8'));
+const chartPath = './kubernetes/helm/matchexec/Chart.yaml';
+let chart = readFileSync(chartPath, 'utf8');
+chart = chart.replace(/^version: .+$/m, `version: ${version}`);
+chart = chart.replace(/^appVersion: .+$/m, `appVersion: "${version}"`);
+writeFileSync(chartPath, chart);
+console.log(`Updated Chart.yaml to version ${version}`);


### PR DESCRIPTION
## Summary
This PR adds automated Helm chart publishing to the release workflow and implements version synchronization between `package.json` and the Helm `Chart.yaml` file.

## Key Changes

- **New Helm Publishing Workflow**: Added `helm-publish` job to the release workflow that packages and pushes the Helm chart to GHCR OCI registry after each release
- **Enhanced Release Notes**: Updated release template to include Helm chart installation instructions
- **Version Synchronization Script**: Created `scripts/update-helm-version.mjs` to automatically sync both `version` and `appVersion` fields in `Chart.yaml` with `package.json`
- **Improved Version Validation**: Enhanced the `check-versions` job in PR checks to:
  - Validate both `version` and `appVersion` fields in `Chart.yaml`
  - Add Helm linting to catch chart configuration issues
  - Provide clearer error messages distinguishing between version and appVersion mismatches
  - Report all validation failures before exiting
- **Updated Chart Version**: Bumped `Chart.yaml` version from 0.1.0 to 0.8.0 to match current application version
- **NPM Version Hook**: Added `version` script to `package.json` that automatically updates Helm chart versions when npm version commands are run

## Implementation Details

The version synchronization is now automated through npm's built-in `version` script hook, which runs whenever version commands are executed. This ensures the Helm chart stays in sync with the application version without manual intervention. The PR checks workflow now validates both chart fields and includes Helm linting to catch configuration issues early.

https://claude.ai/code/session_01QUHxVvGcYRvDrB4SSfSYvu